### PR TITLE
support for adding url query string

### DIFF
--- a/lib/cdnify.js
+++ b/lib/cdnify.js
@@ -48,10 +48,14 @@ module.exports = function(str, data) {
     }
 
     var log = hexo.log || console.log;
+    var tail = process.env.HEXO_CDN_QS || options.tail || '';
+    if (tail) {
+        tail = '?' + tail;
+    }
 
     var base = options.base,
         rewriteURL = function(origUrl) {
-            return isLocalPath(origUrl) ? Url.resolve(base, origUrl) : origUrl;
+            return isLocalPath(origUrl) ? Url.resolve(base, origUrl) + tail : origUrl;
         },
         soup = new Soup(str);
 


### PR DESCRIPTION
Adding `tail` parameters and supporting `HEXO_CDN_QS` environment variables, avoiding CDN caching。

tail:

```
cdn:
  enable: true
  base: //cdn.com
  tail: v2
```

or

```
$ HEXO_CDN_QS=v2 hexo build
```

It will replace `./vendors/index.css` to `//cdn.com/vendors/index.css?v2`
